### PR TITLE
Striping String to check ParseBoolean

### DIFF
--- a/jdk/src/share/classes/java/lang/Boolean.java
+++ b/jdk/src/share/classes/java/lang/Boolean.java
@@ -119,7 +119,7 @@ public final class Boolean implements java.io.Serializable,
      * @since 1.5
      */
     public static boolean parseBoolean(String s) {
-        return ((s != null) && s.equalsIgnoreCase("true"));
+        return ((s != null) && s.strip().equalsIgnoreCase("true"));
     }
 
     /**


### PR DESCRIPTION
Strip the String to avoid spaces and check for true values